### PR TITLE
Modified prepare_mkl.sh and Makfile

### DIFF
--- a/code/intel/convolution/mkl_conv/Makefile
+++ b/code/intel/convolution/mkl_conv/Makefile
@@ -14,7 +14,9 @@
 # limitations under the License.
 #*******************************************************************************
 
-#MKLLIB=mklml_intel
+ifeq ($(MKLROOT),)
+$(error MKLROOT must be defined. It's possible to use Intel MKL 2017 Gold and higher or Intel MKLML package from IntelCaffe: https://github.com/intel/caffe/releases)
+endif
 
 RETURN_STRING=$(shell sh ../../externals/prepare_mkl.sh)
 
@@ -29,11 +31,11 @@ CFLAGS   =  -O3  -Wall -I$(MKLROOT)/include -qopenmp -std=c++11
 OBJS     =  std_conv_bench.o
 
 ifeq ($(MKLLIB), mklml_intel)
-EXTRALIB = -Wl,--start-group -L$(MKLROOT)/lib -lmklml_intel -liomp5 -lpthread -lm -ldl
+EXTRALIB = -L$(MKLROOT)/lib -lmklml_intel -liomp5 -lpthread -lm -ldl
 endif
 
 ifeq ($(MKLLIB), mkl_rt)
-EXTRALIB = -Wl,--start-group $(MKLROOT)/lib/intel64/libmkl_intel_lp64.a $(MKLROOT)/lib/intel64/libmkl_intel_thread.a $(MKLROOT)/lib/intel64/libmkl_core.a -Wl,--end-group -liomp5 -lpthread -lm -ldl
+EXTRALIB = -L$(MKLROOT)/lib/intel64/ -lmkl_rt -liomp5 -lpthread -lm -ldl
 endif
 
 all : std_conv_bench

--- a/code/intel/externals/prepare_mkl.sh
+++ b/code/intel/externals/prepare_mkl.sh
@@ -6,41 +6,6 @@ FindLibrary()
   LOCALMKL=`find $1 -name libmklml_intel.so`   # name of MKL lib
 }
 
-GetVersionName()
-{
-  VERSION_LINE=0
-  if [ $1 ]; then
-    VERSION_LINE=`grep __INTEL_MKL_BUILD_DATE $1/include/mkl_version.h 2>/dev/null | sed -e 's/.* //'`
-  fi
-  if [ -z $VERSION_LINE ]; then
-    VERSION_LINE=0
-  fi
-  echo $VERSION_LINE  # Return Version Line
-}
-
-# MKL
-DST=`dirname $0`
-OMP=0 
-VERSION_MATCH=20160906
-ARCHIVE_BASENAME=mklml_lnx_2017.0.1.20161005.tgz
-MKL_CONTENT_DIR=`echo $ARCHIVE_BASENAME | rev | cut -d "." -f 2- | rev`
-GITHUB_RELEASE_TAG=self_containted_MKLGOLD_u1
-MKLURL="https://github.com/intel/caffe/releases/download/$GITHUB_RELEASE_TAG/$ARCHIVE_BASENAME"
-# there are diffrent MKL lib to be used for GCC and for ICC
-reg='^[0-9]+$'
-VERSION_LINE=`GetVersionName $MKLROOT`
-# Check if MKLROOT is set if positive then set one will be used..
-if [ -z $MKLROOT ] || [ $VERSION_LINE -lt $VERSION_MATCH ]; then
-  # ..if MKLROOT is not set then check if we have MKL downloaded in proper version
-  VERSION_LINE=`GetVersionName $DST/$MKL_CONTENT_DIR`
-  if [ $VERSION_LINE -lt $VERSION_MATCH ] ; then
-    #...If it is not then downloaded and unpacked
-    wget --no-check-certificate -P $DST $MKLURL -O $DST/$ARCHIVE_BASENAME
-    tar -xzf $DST/$ARCHIVE_BASENAME -C $DST
-  fi
-  FindLibrary $DST
-  MKLROOT=$PWD/`echo $LOCALMKL | sed -e 's/lib.*$//'`
-fi
 # Check what MKL lib we have in MKLROOT
 if [ -z `find $MKLROOT -name libmkl_rt.so -print -quit` ]; then
   # mkl_rt has not been found; we are dealing with MKLML
@@ -51,9 +16,8 @@ if [ -z `find $MKLROOT -name libmkl_rt.so -print -quit` ]; then
   fi
 
   LIBRARIES=`basename $LOCALMKL | sed -e 's/^.*lib//' | sed -e 's/\.so.*$//'`
-  OMP=1
 else
   LIBRARIES="mkl_rt"
 fi 
 
-echo $MKLROOT $LIBRARIES $OMP
+echo $MKLROOT $LIBRARIES


### PR DESCRIPTION
1) I would suggest avoiding downloading of MKLML package. There are a number of reasons:
- MKL can be installed on the system already. There no need to download it again. 
- If someone wants to use only Intel MKL, there is no need to download MKLML package. 
- The version of MKL is hardcoded in prepare_mkl.sh script. 
2) I have modified prepare_mkl.sh script. Now it checks Intel MKL or MKLML and sets needed library into link line. 
3) I think it makes sense to use dynamic linking for Intel MKL and MKLML. It allows to user manager MKL versions by changing path in LD_LIBRARY_PATH variable without benchmark rebuilding.
